### PR TITLE
Update SSL_CERTS docs + kontena certificate import/export

### DIFF
--- a/using-kontena/loadbalancer.md
+++ b/using-kontena/loadbalancer.md
@@ -169,9 +169,28 @@ To use Let's Encrypt certificates with the Kontena Load Balancer:
 
 Once you have the Let's Encrpyt certificates for your domain visible in `kontena certificate list`, you may proceed to deploy them to the Kontena Load Balancer.
 
-#### Deploying SSL certificates from Kontena Vault `certificates`
+### Using externally managed SSL certificates
 
-The Let's Encrypt certificate stored in the Kontena Vault certificate is deployed to the Kontena Load Balancer using an `SSL_CERT_*` [env certificate](stack-file.md#using-certificates):
+Externally managed SSL certificates can also be imported into Kontena, for use in the Kontena Load Balancer. These can be self-signed certificates, or any other non-Let's Encrypt certificates, such as wildcard certificates.
+
+To import a certificate, you need the certificate, the private key and any optional intermediate certificate chain certs as separate PEM files:
+
+```
+$ kontena certificate import --private-key key.pem --chain ca-chain.pem cert.pem
+ [done] Importing certificate from cert.pem...     
+development/test:
+  subject: test
+  valid until: 2017-11-30T19:30:52Z
+  alt names:
+    - test-1
+  auto renewable: false
+```
+
+These imported certificates can be used identically to Let's Encrypt managed certificates, except that they will not be auto-renewed by Kontena.
+
+### Deploying SSL certificates from Kontena Vault `certificates`
+
+The SSL certificate stored in the Kontena Vault certificate is deployed to the Kontena Load Balancer using an `SSL_CERT_*` [env certificate](stack-file.md#using-certificates):
 
 ```yaml
 services:
@@ -245,11 +264,13 @@ services:
     # {% endif %}
 ```
 
-### Using externally managed SSL certificates
+### Using older secrets-based certificates
 
-The newer Kontena Certificates model used for auto-renewable Let's Encrypt certificates does not yet support importing externally managed certificates.
+Previous releases of Kontena did not support the new `certificates` model, and certificate bundles were stored and used from [Kontena Vault secrets](vault.md).
 
-To deploy externally managed SSL certificates, you may used the older Kontena Vault `secrets` based method.
+These certificate bundles must be structured in a certain way to be used with the Kontena Load Balancer.
+
+With newer versions of Kontena, the use of the `kontena certificate` commands is recommended.
 
 #### Preparing the SSL Certificate bundle
 

--- a/using-kontena/stack-file.md
+++ b/using-kontena/stack-file.md
@@ -505,7 +505,7 @@ services:
 
 #### Using `certificates`
 
-In the example below, the Kontena Platform will expose the bundled X.509 certificate, private key and any certificate chain for the `example.com` certificate as an environment variable `SSL_CERTS` to the Kontena Load Balancer Service.
+In the example below, the Kontena Platform will expose the bundled X.509 certificate, private key and any certificate chain for the `example.com` certificate as an `SSL_CERT_*` environment variable to the Kontena Load Balancer Service.
 
 ```yaml
 services:
@@ -513,9 +513,13 @@ services:
     image: kontena/lb
     certificates:
       - subject: example.com
-        name: SSL_CERTS
+        name: SSL_CERT_example.com
         type: env
 ```
+
+Multiple certificates can be deployed using separate `SSL_CERT_*` envs.
+
+Alternatively, multiple certificates can be deployed with the same `SSL_CERTS` env, and all of the certificates will be combined into a single environment variable. You must take into account the [limitations on the number of SSL certificates](#limitations-on-the-number-of-ssl-certificates)] when using the combined `SSL_CERTS` env.
 
 #### Using Kontena Volumes
 

--- a/using-kontena/vault.md
+++ b/using-kontena/vault.md
@@ -187,3 +187,22 @@ valid_until: '2017-11-22T09:55:00.000+00:00'
 alt_names: []
 auto_renewable: true
 ```
+
+#### Exporting a certificate
+
+To export a managed certificate, use:
+
+```
+$ kontena certificate export example.com
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+-----BEGIN RSA PRIVATE KEY-----
+...
+-----END RSA PRIVATE KEY-----
+```
+
+This outputs the entire certificate bundle by default. Use the `--cert`, `--chain` or `--key` options to export the different parts of the certificate separately.

--- a/using-kontena/vault.md
+++ b/using-kontena/vault.md
@@ -150,10 +150,10 @@ services:
     certificates:
       - subject: www.example.com
         type: env
-        name: SSL_CERTS
+        name: SSL_CERT_www.example.com
 ```
 
-Kontena will inject the certificate from the vault into `SSL_CERTS` environment variable for the service instance container.
+Kontena will inject the certificate from the vault into the `SSL_CERT_*` environment variable for the service instance container.
 
 #### Renewing Let's Encrypt certificates
 


### PR DESCRIPTION
These `SSL_CERT_*` changes should be released once `kontena/lb:latest` supports these - currently support is in `kontena/lb:1.0` (per https://github.com/kontena/kontena-loadbalancer/pull/28)and `kontena/lb:edge` (per https://github.com/kontena/kontena-loadbalancer/pull/35), but AFAIK not yet `kontena/lb:latest`.

The `kontena certificate import/export` are for the 1.4.1 release.