### PR TITLE
Fix broken symbols in compose compatibility matrix

### DIFF
--- a/references/stack-file-vs-compose.md
+++ b/references/stack-file-vs-compose.md
@@ -33,8 +33,8 @@
 | labels | ✗ |
 | links | ✓ |
 | logging | ✓ |
-| mac_address | x |
-| network_mode | v |
+| mac_address | ✗ |
+| network_mode | ✓ |
 | networks | ✗ |
 | oom_score_adj | ✗ |
 | pid | ✓ |


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/224971/35047992-5cbd9b48-fba4-11e7-8d54-27f5c1acebbf.png)

@nevalla had a hunch that the list also has some error
