### PR TITLE
Fix reference menu

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -70,6 +70,7 @@
   * [Using nsenter to access a node without SSH](guides/administration/using-nsenter-to-access-a-node-without-ssh.md)
 * [Configure Platform](guides/configure-platform.md)
   * [Use private Docker images](guides/configure-platform/images-from-private-repos.md)
+
 ## References
 
 * [Cheat Sheet](references/cheat-sheet.md)


### PR DESCRIPTION
Missing newline caused the reference top level menu to disappear.